### PR TITLE
add classic build building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ addons:
 
 install: luarocks install --local luacheck
 before_script: /home/travis/.luarocks/bin/luacheck . -qo "011"
-script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
+script:
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.2 -w 0
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install: luarocks install --local luacheck
 before_script: /home/travis/.luarocks/bin/luacheck . -qo "011"
 script:
   - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
-  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.2 -w 0
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | WOWI_API_TOKEN= bash -s -- -g 1.13.2
 
 notifications:
   email:

--- a/BugSack.toc
+++ b/BugSack.toc
@@ -1,4 +1,9 @@
+#@retail@
 ## Interface: 80200
+#@end-retail@
+#@non-retail@
+# ## Interface: 11302
+#@end-non-retail@
 ## Version: @project-version@
 ## Title: BugSack
 ## Notes: Toss those bugs inna sack.


### PR DESCRIPTION
Will work once @nebularg adds the toc version unsetting because there currently is no classic project for BugSack on WowI. You're probably waiting for dolby to finish the new layout, I guess?

Edit: Now works without needing the packager change.