### PR TITLE
Add a build for WoW Classic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ addons:
 
 install: luarocks install --local luacheck
 before_script: /home/travis/.luarocks/bin/luacheck . -qo "011"
-script: curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
+script:
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | WOWI_API_TOKEN= bash -s -- -g 1.13.5
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
 
 notifications:
   email:

--- a/BugSack.toc
+++ b/BugSack.toc
@@ -1,4 +1,9 @@
+#@retail@
 ## Interface: 80200
+#@end-retail@
+#@non-retail@
+# ## Interface: 11305
+#@end-non-retail@
 ## Version: @project-version@
 ## Title: BugSack
 ## Notes: Toss those bugs inna sack.


### PR DESCRIPTION
The addon works on WoW Classic, but is listed out of date because it requires a different interface value. BigWigMods packager handles this by adding some tags to the toc.