### PR TITLE
Hold position on the current bug displayed if the user is scrolling

### DIFF
--- a/sack.lua
+++ b/sack.lua
@@ -124,7 +124,8 @@ end
 hooksecurefunc(addon, "UpdateDisplay", function()
 	if not window or not window:IsShown() then return end
 	-- can't just hook it right in because it would pass |self| as forceRefresh
-	updateSackDisplay(true)
+	local forceRefresh = currentErrorIndex and currentSackContents and currentErrorIndex == #currentSackContents
+	updateSackDisplay(forceRefresh)
 end)
 
 -- Only invoked when actually clicking a tab


### PR DESCRIPTION
Hold position on the current bug displayed if the user is scrolling through the bugs.

This is to avoid a problem when a rapidly-occurring bug forces a complete refresh and forces the display position back to the end of the bugs list repeatedly & rapidly. A rapid-bug prevented a user from scrolling through the bugs to find the first bug which broke an addon, especially if there are many bugs to scroll through and the rapid-bug occurs in a loop or in OnUpdate for example. That made it extremely difficult for a developer or a user to identify the real cause of bugs in an addon, to get support and get a rapid bug fix. This resolves Issue #68 Rapid Bugs Prevent Scroll Back to Previous Bugs.