### PR TITLE
Workaround for unprintable characters in locals

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -219,14 +219,14 @@ do
 
 	local errorFormat = "%dx %s"
 	local errorFormatLocals = "%dx %s\n\nLocals:\n%s"
-	function addon:FormatError(err)
+	function addon:FormatError(err, unprintableLocals)
 		if not err.locals then
 			local s = colorStack(tostring(err.message) .. (err.stack and "\n"..tostring(err.stack) or ""))
 			local l = colorLocals(tostring(err.locals))
 			return errorFormat:format(err.counter or -1, s, l)
 		else
 			local s = colorStack(tostring(err.message) .. (err.stack and "\n"..tostring(err.stack) or ""))
-			local l = colorLocals(tostring(err.locals))
+			local l = unprintableLocals and "Skipped because of unprintable characters" or colorLocals(tostring(err.locals))
 			return errorFormatLocals:format(err.counter or -1, s, l)
 		end
 	end

--- a/sack.lua
+++ b/sack.lua
@@ -88,6 +88,9 @@ local function updateSackDisplay(forceRefresh)
 		end
 		countLabel:SetText(countFormat:format(currentErrorIndex, size))
 		textArea:SetText(addon:FormatError(eo))
+		if textArea:GetText() == "" then
+			textArea:SetText(addon:FormatError(eo, true))
+		end
 
 		if currentErrorIndex >= size then
 			nextButton:Disable()


### PR DESCRIPTION
Sometimes we can get unprintable characters in error messages that result in BugSack's error frame not displaying an error. These characters are usually related to locals of the error, so we can still try to display error and debugstack.

Simple example of error with unprintable character will be:
`/run local s = "\1" s()`

Before fix
![image](https://github.com/user-attachments/assets/6ebb3862-7739-4a51-9781-aad689b2a17b)

After fix
![image](https://github.com/user-attachments/assets/860f11b1-7b93-40a2-a8e3-d78c304d4d27)