### PR TITLE
Set the fontobject to the correct frame in config.lua

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -112,8 +112,8 @@ local function InitializeSettings()
 		local fonts =
 			{ "GameFontHighlightSmall", "GameFontHighlight", "GameFontHighlightMedium", "GameFontHighlightLarge" }
 		addon.db.fontSize = fonts[value]
-		if _G.BugSackFrameScrollText then
-			_G.BugSackFrameScrollText:SetFontObject(_G[fonts[value]])
+		if _G.BugSackScrollText then
+			_G.BugSackScrollText:SetFontObject(_G[fonts[value]])
 		end
 	end
 


### PR DESCRIPTION
`BugSackFrameScrollText` doesn’t seem to exist at all. This explains why a changed font got applied only after reload (via sack.lua [L422](https://github.com/funkydude/BugSack/blob/03d653a105e3ebf3b9f30fc46a4b645de0350cd2/sack.lua#L418-L422)).

