### PR TITLE
Add categories to TOC

### DIFF
--- a/BugSack.toc
+++ b/BugSack.toc
@@ -23,7 +23,6 @@
 ## Category-esMX: Herramientas de Desarrollo
 ## Category-frFR: Outils de Développement
 ## Category-itIT: Strumenti di sviluppo
-## Category-koKR:
 ## Category-ptBR: Ferramentas de Desenvolvimento
 ## Category-ruRU: Инструменты разработки
 ## Category-zhCN: 开发工具


### PR DESCRIPTION
I added the Development Tools category to the TOC; this makes it group up with other related addons in the WoW addon list.

Note that a similar change has to be made to BugGrabber as well; but I couldn't find the repository for that to make a pull request.

The translations are taken from the suggested list of categories on the WoW wiki: https://warcraft.wiki.gg/wiki/Addon_Categories#Development_Tools