### PR TITLE
Add config option to default to current session tab

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -21,6 +21,18 @@ local function InitializeSettings()
 	)
 	Settings.CreateCheckbox(category, autoPopupSetting, L.autoDesc)
 
+	-- Default to current session setting
+	local defaultCurrentSessionSetting = Settings.RegisterAddOnSetting(
+		category,
+		"BUGSACK_DEFAULT_CURRENT_SESSION",
+		"defaultCurrentSession",
+		addon.db,
+		Settings.VarType.Boolean,
+		L["Default to current session"],
+		Settings.Default.False
+	)
+	Settings.CreateCheckbox(category, defaultCurrentSessionSetting, L.defaultCurrentSessionDesc)
+
 	-- Chatframe output setting
 	local chatFrameSetting = Settings.RegisterAddOnSetting(
 		category,

--- a/core.lua
+++ b/core.lua
@@ -154,6 +154,9 @@ do
 		if type(sv.useMaster) ~= "boolean" then
 			sv.useMaster = false
 		end
+		if type(sv.defaultCurrentSession) ~= "boolean" then
+			sv.defaultCurrentSession = false
+		end
 		addon.db = sv
 
 		-- Make sure we grab any errors fired before bugsack loaded.

--- a/locales.lua
+++ b/locales.lua
@@ -56,6 +56,8 @@ L.useMaster = "Use 'Master' sound channel"
 L.useMasterDesc = "Play the chosen error sound over the 'Master' sound channel instead of the default one."
 L.addonCompartment = "Addon compartment icon"
 L.addonCompartment_desc = "Creates a menu entry in the 'Addon Compartment' for BugSack."
+L["Default to current session"] = "Default to current session"
+L.defaultCurrentSessionDesc = "When opening BugSack, show bugs from the current session instead of all sessions."
 
 local locale = GetLocale()
 if locale == "deDE" then

--- a/sack.lua
+++ b/sack.lua
@@ -503,10 +503,13 @@ function addon:OpenSack()
 		return
 	end
 
-	-- XXX we should show the most recent error (from this session) that has not previously been shown in the sack
-	-- XXX so, 5 errors are caught, the user clicks the icon, we start it at the first of those 5 errors.
-	--[[if not currentSackContents then
-		currentSackContents = BugGrabber:GetDB(currentSackSession)
-	end]]
+	-- Reset to configured default tab on each open
+	if addon.db.defaultCurrentSession then
+		state = "BugSackTabSession"
+	else
+		state = "BugSackTabAll"
+	end
+	lastState = nil
+
 	show()
 end


### PR DESCRIPTION
Adds a "Default to current session" checkbox in BugSack settings. When enabled, opening BugSack starts on the "Current session" tab instead of "All bugs".

- New saved variable `defaultCurrentSession` (boolean, default false)
- Resets to the configured default tab each time the sack is opened

Fixes #184